### PR TITLE
update(reservation): use updated room images in stay pricing table

### DIFF
--- a/src/app/reservation/page.tsx
+++ b/src/app/reservation/page.tsx
@@ -16,7 +16,7 @@ type PriceSection = {
 const priceSections: PriceSection[] = [
   {
     label: '1室1名',
-    image: '/images/room1_1.jpg',
+    image: '/images/S__36700182_0.jpg',
     iconType: 'single',
     content: (
       <p className="text-[#332211] font-bold text-xs md:text-lg leading-tight">
@@ -26,7 +26,7 @@ const priceSections: PriceSection[] = [
   },
   {
     label: '1室2~3名',
-    image: '/images/room2_8.jpg',
+    image: '/images/S__36700183_0.jpg',
     iconType: 'group',
     content: (
       <div className="text-[#332211] text-left w-full max-w-[142px] md:max-w-[170px] mx-auto">


### PR DESCRIPTION
Switch the single and group occupancy pricing photos to the new room images already used on the rooms pages.